### PR TITLE
Potential fix for code scanning alert no. 63: Log Injection

### DIFF
--- a/recipe_management_backend/src/main/java/com/nus_iss/recipe_management/service/impl/RecipeServiceImpl.java
+++ b/recipe_management_backend/src/main/java/com/nus_iss/recipe_management/service/impl/RecipeServiceImpl.java
@@ -333,7 +333,8 @@ public class RecipeServiceImpl implements RecipeService {
 
                         try {
                             recipeIngredientsMappingRepository.save(mapping);
-                            log.info("Added ingredient {} to recipe {}", ingredient.getName(), existingRecipe.getTitle());
+                            String sanitizedTitle = existingRecipe.getTitle().replace('\n', ' ').replace('\r', ' ');
+                            log.info("Added ingredient {} to recipe {}", ingredient.getName(), sanitizedTitle);
                         } catch (Exception e) {
                             log.error("Failed to map ingredient to recipe: {}", e.getMessage(), e);
                         }


### PR DESCRIPTION
Potential fix for [https://github.com/yy-personal/rmmps/security/code-scanning/63](https://github.com/yy-personal/rmmps/security/code-scanning/63)

To fix the issue, sanitize the user-provided `existingRecipe.getTitle()` before logging it. Specifically:
1. Remove newline (`\n`) and carriage return (`\r`) characters from the recipe title to prevent log injection.
2. Use a method like `String.replace()` to replace these characters with a space or another safe character.
3. Ensure the sanitized value is used in the logging statement.

The fix will be applied in the `RecipeServiceImpl` class where the logging statement is located.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
